### PR TITLE
remove quotes wrapping eslint path

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:watch": "tsc --watch",
     "clean": "rimraf my-element.{d.ts,d.ts.map,js,js.map} test/my-element.{d.ts,d.ts.map,js,js.map} test/my-element_test.{d.ts,d.ts.map,js,js.map}",
     "lint": "npm run lint:lit-analyzer && npm run lint:eslint",
-    "lint:eslint": "eslint 'src/**/*.ts'",
+    "lint:eslint": "eslint src/**/*.ts",
     "lint:lit-analyzer": "lit-analyzer",
     "format": "prettier src/* --write",
     "docs": "npm run docs:clean && npm run build && npm run analyze && npm run docs:build && npm run docs:assets && npm run docs:gen",


### PR DESCRIPTION
`npm run lint` fails because eslint does not like the `'`s wrapping its target path. Removing the single quotes fixes `npm run lint`