### PR TITLE
Include build-script to make use of rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
+    "build:element": "npm run build && rollup -c",
     "clean": "rimraf my-element.{d.ts,d.ts.map,js,js.map} test/my-element.{d.ts,d.ts.map,js,js.map} test/my-element_test.{d.ts,d.ts.map,js,js.map}",
     "lint": "npm run lint:lit-analyzer && npm run lint:eslint",
     "lint:eslint": "eslint 'src/**/*.ts'",


### PR DESCRIPTION
As there already is a [rollup.config.js](https://github.com/PolymerLabs/lit-element-starter-ts/blob/master/rollup.config.js) included in this project I expected that there would be a build-script too which makes use of this file. So far rollup is only used for the [docs:build](https://github.com/PolymerLabs/lit-element-starter-ts/blob/master/package.json#L21) and [checksize](https://github.com/PolymerLabs/lit-element-starter-ts/blob/master/package.json#L28) task. Including this new script would help beginners to simplify using the component later on. Throughout the docs roolup is mentioned first when talking about building your component so I think it's fair to include a step to build the component. An alternative would be to also include a webpack config and also step for that but I'd argument for rollup to keep the starter project simple